### PR TITLE
Disable xdebug when running phpunit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,8 +98,11 @@ phpunit:
     - db-seeding
   script:
     - php -v
+    - sudo cp /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.bak
+    - echo "" | sudo tee /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
     - ./vendor/phpunit/phpunit/phpunit --version
     - php -d short_open_tag=off ./vendor/phpunit/phpunit/phpunit -v --colors=never --stderr
+    - sudo cp /usr/local/etc/php/conf.d/docker-php-ext-xdebug.bak /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
   artifacts:
     paths:
       - ./storage/logs # for debugging


### PR DESCRIPTION
When not using the coverage options of phpunit, xdebug slows down
testing significantly.

Thanks to @JasonVarga for his gist: https://gist.github.com/jasonvarga/6f97a6faf870b32067982eea068d3e71